### PR TITLE
Add Authorization: header to the idempo key

### DIFF
--- a/lib/idempo.rb
+++ b/lib/idempo.rb
@@ -141,6 +141,7 @@ class Idempo
     d = Digest::SHA256.new
     d << req.url << "\n"
     d << req.request_method << "\n"
+    d << req.get_header('HTTP_AUTHORIZATION').to_s << "\n"
     while chunk = req.env['rack.input'].read(1024 * 65)
       d << chunk
     end


### PR DESCRIPTION
If two different clients send exactly the same payload to the same URL, the
requests will be considered idempotent while their generation also depends
on the "account id". Closest we can get to an "account id" is the auth header.