### PR TITLE
Use lock refresh instead of "atomic save"

### DIFF
--- a/lib/idempo/redis_backend.rb
+++ b/lib/idempo/redis_backend.rb
@@ -19,7 +19,7 @@ class Idempo::RedisBackend
   REFRESH_LOCK_SCRIPT = <<~EOL
     redis.replicate_commands()
     if redis.call("get", KEYS[1]) == ARGV[1] then
-      -- we are still holding the lock, we can go ahead and set it
+      -- we are still holding the lock, extend its TTL
       redis.call("expire", KEYS[1], ARGV[2])
       return "ok"
     else


### PR DESCRIPTION
It seems that Lua scripts with large payloads in ARGV cause some grief to our Redis instance, so we need to experimnent a bit. While this solution is less sound and makes a race condition possible, it might be a sensible tradeoff