### PR TITLE
Use autoload for internal modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [1.2.1] - 2024-02-22
 
 - Use autoloading for internal modules. A user using Redis does not have to load the ActiveRecord storage backend, for example
+- Ensure that the original Rack response body receives a `close` when reading out for caching
 
 ## [1.2.0] - 2024-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.2.1] - 2024-02-22
+
+- Use autoloading for internal modules. A user using Redis does not have to load the ActiveRecord storage backend, for example
+
 ## [1.2.0] - 2024-02-22
 
 - Use memory locking in addition to DB locking in `ActiveRecordBackend`

--- a/lib/idempo.rb
+++ b/lib/idempo.rb
@@ -8,16 +8,17 @@ require "msgpack"
 require "zlib"
 require "set"
 
-require_relative "idempo/active_record_backend"
-require_relative "idempo/concurrent_request_error_app"
-require_relative "idempo/malformed_key_error_app"
-require_relative "idempo/memory_backend"
-require_relative "idempo/redis_backend"
-require_relative "idempo/request_fingerprint"
-require_relative "idempo/memory_lock"
-require_relative "idempo/version"
+require "idempo/version"
 
 class Idempo
+  autoload :ConcurrentRequestErrorApp, "idempo/concurrent_request_error_app"
+  autoload :MalformedKeyErrorApp, "idempo/malformed_key_error_app"
+  autoload :MemoryBackend, "idempo/memory_backend"
+  autoload :RedisBackend, "idempo/redis_backend"
+  autoload :ActiveRecordBackend, "idempo/active_record_backend"
+  autoload :RequestFingerprint, "idempo/request_fingerprint"
+  autoload :MemoryLock, "idempo/memory_lock"
+
   DEFAULT_TTL_SECONDS = 30
   SAVED_RESPONSE_BODY_SIZE_LIMIT = 4 * 1024 * 1024
 

--- a/lib/idempo/concurrent_request_error_app.rb
+++ b/lib/idempo/concurrent_request_error_app.rb
@@ -1,5 +1,3 @@
-require "json"
-
 class Idempo::ConcurrentRequestErrorApp
   RETRY_AFTER_SECONDS = 2.to_s
 

--- a/lib/idempo/malformed_key_error_app.rb
+++ b/lib/idempo/malformed_key_error_app.rb
@@ -1,5 +1,3 @@
-require "json"
-
 class Idempo::MalformedKeyErrorApp
   def self.call(env)
     res = {

--- a/lib/idempo/version.rb
+++ b/lib/idempo/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Idempo
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
It is prudent to not have people load the code they would never use.

Closes #19