### PR TITLE
Handle ActionDispatch::Response::RackBody as body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,16 @@ jobs:
     name: Specs
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    env:
+      IDEMPO_RACK_VERSION: "2.0"
     strategy:
       matrix:
         ruby:
           - "2.7"
           - "3.2"
+        rack:
+          - "2.0"
+          - "3.0"
     services:
       mysql:
         image: mysql:5.7
@@ -65,10 +70,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
-        env:
-          IDEMPO_RACK_VERSION: "2.0"
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: false
@@ -76,24 +80,6 @@ jobs:
       - name: RSpec with rack v2
         run: bundle exec rspec
         env:
-          IDEMPO_RACK_VERSION: "2.0"
-          MYSQL_HOST: 127.0.0.1
-          MYSQL_PORT: 3306
-          PGHOST: localhost
-          PGUSER: postgres
-          PGPASSWORD: postgres
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        env:
-          IDEMPO_RACK_VERSION: "3.0"
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: false
-          bundler: 2.4 # Ruby 2.6-2.7 only works with Bundler 2.4
-      - name: RSpec with rack v3
-        run: bundle exec rspec
-        env:
-          IDEMPO_RACK_VERSION: "3.0"
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
           PGHOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: false
-          bundler: 2.4 # Ruby 2.6-2.7 only works with Bundler 2.4
+          bundler-cache: true
+          # bundler: 2.4 # Ruby 2.6-2.7 only works with Bundler 2.4
       - name: RSpec with rack v2
         run: bundle exec rspec
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.7'
+          - "2.7"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -40,8 +40,8 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.7'
-          - '3.2'
+          - "2.7"
+          - "3.2"
     services:
       mysql:
         image: mysql:5.7
@@ -70,9 +70,18 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: RSpec
+      - name: RSpec with rack v3
         run: bundle exec rspec
         env:
+          MYSQL_HOST: 127.0.0.1
+          MYSQL_PORT: 3306
+          PGHOST: localhost
+          PGUSER: postgres
+          PGPASSWORD: postgres
+      - name: RSpec with rack v2
+        run: bundle exec rspec
+        env:
+          IDEMPO_RACK_VERSION: "2.0"
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
           PGHOST: localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     env:
-      IDEMPO_RACK_VERSION: "2.0"
+      IDEMPO_RACK_VERSION: ${{ matrix.rack }}
     strategy:
       matrix:
         ruby:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-          # bundler: 2.4 # Ruby 2.6-2.7 only works with Bundler 2.4
-      - name: RSpec with rack v2
+      - name: RSpec
         run: bundle exec rspec
         env:
           MYSQL_HOST: 127.0.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,11 @@ jobs:
           PGHOST: localhost
           PGUSER: postgres
           PGPASSWORD: postgres
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: false
       - name: RSpec with rack v3
         run: bundle exec rspec
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
+          bundler-cache: false
       - name: RSpec with rack v2
         run: bundle exec rspec
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,12 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
+        env:
+          IDEMPO_RACK_VERSION: "2.0"
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: false
+          bundler: 2.4 # Ruby 2.6-2.7 only works with Bundler 2.4
       - name: RSpec with rack v2
         run: bundle exec rspec
         env:
@@ -81,9 +84,12 @@ jobs:
           PGPASSWORD: postgres
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
+        env:
+          IDEMPO_RACK_VERSION: "3.0"
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: false
+          bundler: 2.4 # Ruby 2.6-2.7 only works with Bundler 2.4
       - name: RSpec with rack v3
         run: bundle exec rspec
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,18 +70,19 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: RSpec with rack v3
+      - name: RSpec with rack v2
         run: bundle exec rspec
         env:
+          IDEMPO_RACK_VERSION: "2.0"
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
           PGHOST: localhost
           PGUSER: postgres
           PGPASSWORD: postgres
-      - name: RSpec with rack v2
+      - name: RSpec with rack v3
         run: bundle exec rspec
         env:
-          IDEMPO_RACK_VERSION: "2.0"
+          IDEMPO_RACK_VERSION: "3.0"
           MYSQL_HOST: 127.0.0.1
           MYSQL_PORT: 3306
           PGHOST: localhost

--- a/idempo.gemspec
+++ b/idempo.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "rack", "~> #{ENV.fetch('IDEMPO_RACK_VERSION', '3.0')}"
+  spec.add_dependency "rack", "~> #{ENV.fetch("IDEMPO_RACK_VERSION", "3.0")}"
   spec.add_dependency "msgpack"
   spec.add_dependency "measurometer", "~> 1.3"
 
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "redis", "~> 4"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "activerecord"
-  #spec.add_development_dependency "mysql2"
+  spec.add_development_dependency "mysql2"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "standard"
 

--- a/idempo.gemspec
+++ b/idempo.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_dependency "rack"
+  spec.add_dependency "rack", "~> #{ENV.fetch('IDEMPO_RACK_VERSION', '3.0')}"
   spec.add_dependency "msgpack"
   spec.add_dependency "measurometer", "~> 1.3"
 
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "redis", "~> 4"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "activerecord"
-  spec.add_development_dependency "mysql2"
+  #spec.add_development_dependency "mysql2"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "standard"
 

--- a/lib/idempo.rb
+++ b/lib/idempo.rb
@@ -115,6 +115,7 @@ class Idempo
     # does not
     [deflated_message_packed_str, body_chunks]
   ensure
+    # This will not be applied to response bodies of Array type.
     rack_response_body.close if rack_response_body.respond_to?(:close)
   end
 

--- a/lib/idempo.rb
+++ b/lib/idempo.rb
@@ -7,7 +7,7 @@ require "measurometer"
 require "msgpack"
 require "zlib"
 require "set"
-require "rack"
+require 'rack'
 
 require "idempo/version"
 
@@ -56,7 +56,7 @@ class Idempo
       end
 
       status, headers, body = @app.call(env)
-      if Gem::Version.new(Rack.release) >= Gem::Version.new("3.0")
+      if Gem::Version.new(Rack.release) >= Gem::Version.new('3.0')
         # `body` could be of type `ActionDispatch::Response::RackBody` and idempo will not even attempt to store it,
         # we're converting ActionDispatch::Response::RackBody to a storable array format.
         body = body.try(:to_ary) if body.respond_to?(:to_ary)
@@ -123,7 +123,7 @@ class Idempo
   def body_size_within_limit?(response_headers, body)
     return response_headers["Content-Length"].to_i <= SAVED_RESPONSE_BODY_SIZE_LIMIT if response_headers["Content-Length"]
 
-    return false unless body.is_a?(Array) # Arbitrary iterable of unknown size
+    return false unless body.is_a?(Array) || body.respond_to?(:to_ary) # Arbitrary iterable of unknown size
 
     sum_of_string_bytesizes(body) <= SAVED_RESPONSE_BODY_SIZE_LIMIT
   end

--- a/lib/idempo.rb
+++ b/lib/idempo.rb
@@ -7,7 +7,7 @@ require "measurometer"
 require "msgpack"
 require "zlib"
 require "set"
-require 'rack'
+require "rack"
 
 require "idempo/version"
 
@@ -56,7 +56,7 @@ class Idempo
       end
 
       status, headers, body = @app.call(env)
-      if Gem::Version.new(Rack.release) >= Gem::Version.new('3.0')
+      if Gem::Version.new(Rack.release) >= Gem::Version.new("3.0")
         # `body` could be of type `ActionDispatch::Response::RackBody` and idempo will not even attempt to store it,
         # we're converting ActionDispatch::Response::RackBody to a storable array format.
         body = body.try(:to_ary) if body.respond_to?(:to_ary)

--- a/lib/idempo.rb
+++ b/lib/idempo.rb
@@ -55,6 +55,9 @@ class Idempo
       end
 
       status, headers, body = @app.call(env)
+      # `body` could be of type `ActionDispatch::Response::RackBody` and idempo will not even attempt to store it,
+      # we're converting ActionDispatch::Response::RackBody to a storable array format.
+      body = body.try(:to_ary) || body
 
       expires_in_seconds = (headers.delete("X-Idempo-Persist-For-Seconds") || @persist_for_seconds).to_i
       if response_may_be_persisted?(status, headers, body)

--- a/lib/idempo.rb
+++ b/lib/idempo.rb
@@ -62,7 +62,7 @@ class Idempo
       # In some cases `body` could respond to to_ary. In this case, we don't need to call .close on body afterwards.
       #
       # @see https://github.com/rack/rack/blob/main/SPEC.rdoc#the-body-
-      body = body.try(:to_ary) if rack_v3? && body.respond_to?(:to_ary)
+      body = body.to_ary if rack_v3? && body.respond_to?(:to_ary)
 
       if response_may_be_persisted?(status, headers, body)
         # Body is replaced with a cached version since a Rack response body is not rewindable

--- a/lib/idempo.rb
+++ b/lib/idempo.rb
@@ -7,6 +7,7 @@ require "measurometer"
 require "msgpack"
 require "zlib"
 require "set"
+require 'rack'
 
 require "idempo/version"
 
@@ -55,9 +56,11 @@ class Idempo
       end
 
       status, headers, body = @app.call(env)
-      # `body` could be of type `ActionDispatch::Response::RackBody` and idempo will not even attempt to store it,
-      # we're converting ActionDispatch::Response::RackBody to a storable array format.
-      body = body.try(:to_ary) || body
+      if Gem::Version.new(Rack.release) >= Gem::Version.new('3.0')
+        # `body` could be of type `ActionDispatch::Response::RackBody` and idempo will not even attempt to store it,
+        # we're converting ActionDispatch::Response::RackBody to a storable array format.
+        body = body.try(:to_ary) if body.respond_to?(:to_ary)
+      end
 
       expires_in_seconds = (headers.delete("X-Idempo-Persist-For-Seconds") || @persist_for_seconds).to_i
       if response_may_be_persisted?(status, headers, body)

--- a/spec/idempo_spec.rb
+++ b/spec/idempo_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Idempo do
   describe "when no double requests are in progress" do
     let(:app) do
       the_app = ->(env) {
-        [200, {"X-Foo" => "bar"}, [Random.new.bytes(15), env["rack.input"].read]]
+        [200, {"X-Foo" => "bar"}, [Random.new.bytes(15), env["rack.input"]&.read]]
       }
       Idempo.new(the_app, backend: Idempo::MemoryBackend.new)
     end


### PR DESCRIPTION
With our new rails 7.1 project, idempotent requests don't seem to be working. They are not even saved. 

As it turns out, Idempo middleware receives an instance of `ActionDispatch::Response::RackBody` as a body. And since it's not Array, we're not saving that body.

I'm not sure exactly why another project based on rails 7.0 keeps working. Because rails started returning `ActionDispatch::Response::RackBody` pre 7.0 version. I assume, that this could be due to the way how middleware is being inserted (how deep in a stack).

Here is what we do in our `application.rb`:

```ruby
config.middleware.insert_after ActionDispatch::Executor, Idempo, backend: Idempo::ActiveRecordBackend.new
```

And here is an output of `rails middleware`:

```bash
use Rack::Sendfile
use ActionDispatch::Static
use ActionDispatch::Executor
use Idempo
use ActionDispatch::ServerTiming
use ActiveSupport::Cache::Strategy::LocalCache::Middleware
use Rack::Runtime
use Rack::MethodOverride
use ActionDispatch::RequestId
use ActionDispatch::RemoteIp
use Rails::Rack::Logger
use ActionDispatch::ShowExceptions
use WebConsole::Middleware
use ActionDispatch::DebugExceptions
use ActionDispatch::ActionableExceptions
use ActionDispatch::Reloader
use ActionDispatch::Callbacks
use ActiveRecord::Migration::CheckPending
use ActionDispatch::Cookies
use ActionDispatch::Session::CookieStore
use ActionDispatch::Flash
use ActionDispatch::ContentSecurityPolicy::Middleware
use ActionDispatch::PermissionsPolicy::Middleware
use Rack::Head
use Rack::ConditionalGet
use Rack::ETag
use Rack::TempfileReaper
use ActionDispatch::Static
run Banksvc::Application.routes
```

But that is just a wild guess.

As a fix, I suggest trying converting body to array — this proved effective in our project.
