### PR TITLE
Introduce Rack::Lint into our test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
           - "2.7"
           - "3.2"
         rack:
-          - "2.0"
           - "3.0"
+          - "2.0"
     services:
       mysql:
         image: mysql:5.7


### PR DESCRIPTION
Since rack 3 is now supported by Rails, it seems important to ensure that this middleware has a proper support for it. Issues with rack 3 are difficult to notice or debug. To help prevent issues with compatibility and the time that it takes to manually debug and resolve those - I suggest that we integrate `Rack::Lint` into a test suite.

Rack::Lint would ensure that middleware adheres to the SPEC.

Please be patient, since I' still figuring out how this works ;-)

Related documentation (for me to read through multiple times):
- https://github.com/rack/rack/blob/744f92d099653f873ced3380e425a6f82f0c6c6c/UPGRADE-GUIDE.md?plain=1#L185
- https://github.com/rack/rack/blob/744f92d099653f873ced3380e425a6f82f0c6c6c/SPEC.rdoc