### PR TITLE
Don't test against rack v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,11 @@ jobs:
     name: Specs
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-    env:
-      IDEMPO_RACK_VERSION: ${{ matrix.rack }}
     strategy:
       matrix:
         ruby:
           - "2.7"
           - "3.2"
-        rack:
-          - "2.0"
-          - "3.0"
     services:
       mysql:
         image: mysql:5.7


### PR DESCRIPTION
Due to this:
https://github.com/julik/idempo/commit/9a016a3f35bdebdbe5fc760f3edaf57bd0726bbe#r146982882

There is no point in running testsuite twice now. Let's get proper v3 support first and then we can consider how should we run testsuite against rack v2 and v3.