### PR TITLE
Include user identity in request fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.4.0
+
+- `RequestFingerprint` is now a class instead of a module, with an overridable `extract_user_identity` method.
+  The default implementation uses the `Authorization` header when present, and falls back to the Rails session
+  cookie (`_<appname>_session`) when it is not. This prevents cross-user response leakage for apps using
+  cookie-based authentication. For custom auth mechanisms, subclass `RequestFingerprint` and override
+  `extract_user_identity`. Backward compatible — the class still works as the default `compute_fingerprint_via:` value.
+
 ## 1.3.1
 
 - Instead of retaining the ActiveRecord connection in Idempo operations, check it out temporarily from the AR pool.

--- a/examples/jwt_iss_fingerprint.rb
+++ b/examples/jwt_iss_fingerprint.rb
@@ -2,26 +2,15 @@
 # which includes some form of expiration. This means that every time a request is made, the `Authorization`
 # HTTP header may have a different value, and thus the request fingerprint could change every time,
 # even though the idempotency key is the same.
-# For this case, a custom fingerprinting function can be used. For example, if the bearer token is
-# generated in JWT format by the client, it may include the `iss` (issuer) claim, identifying the
-# specific device. This identifier can then be used instead of the entire Authorization header.
+# For this case, you can subclass Idempo::RequestFingerprint and override `extract_user_identity`.
+# For example, if the bearer token is generated in JWT format by the client, it may include the
+# `iss` (issuer) claim, identifying the specific device. This identifier can then be used instead
+# of the entire Authorization header.
 
-module FingerprinterWithIssuerClaim
-  def self.call(idempotency_key, rack_request)
-    d = Digest::SHA256.new
-    d << idempotency_key << "\n"
-    d << rack_request.url << "\n"
-    d << rack_request.request_method << "\n"
-    d << extract_jwt_iss_claim(rack_request) << "\n"
-    while (chunk = rack_request.env["rack.input"].read(1024 * 65))
-      d << chunk
-    end
-    Base64.strict_encode64(d.digest)
-  ensure
-    rack_request.env["rack.input"].rewind
-  end
+class JwtIssFingerprint < Idempo::RequestFingerprint
+  private
 
-  def self.extract_jwt_iss_claim(rack_request)
+  def extract_user_identity(rack_request)
     header_value = rack_request.get_header("HTTP_AUTHORIZATION").to_s
     return header_value unless header_value.start_with?("Bearer ")
 
@@ -39,3 +28,5 @@ module FingerprinterWithIssuerClaim
     SecureRandom.bytes(32)
   end
 end
+
+use Idempo, compute_fingerprint_via: JwtIssFingerprint.new

--- a/lib/idempo/request_fingerprint.rb
+++ b/lib/idempo/request_fingerprint.rb
@@ -1,10 +1,20 @@
-module Idempo::RequestFingerprint
+# frozen_string_literal: true
+
+class Idempo::RequestFingerprint
+  RAILS_SESSION_COOKIE_PATTERN = /\A_[a-z0-9_]+_session\z/i
+
+  # Maintains backward compatibility: Idempo::RequestFingerprint can be passed
+  # directly as the compute_fingerprint_via: value (the default) since it responds to .call.
   def self.call(idempotency_key, rack_request)
+    new.call(idempotency_key, rack_request)
+  end
+
+  def call(idempotency_key, rack_request)
     d = Digest::SHA256.new
     d << idempotency_key << "\n"
     d << rack_request.url << "\n"
     d << rack_request.request_method << "\n"
-    d << rack_request.get_header("HTTP_AUTHORIZATION").to_s << "\n"
+    d << extract_user_identity(rack_request).to_s << "\n"
 
     # Under Rack 3.0 the rack.input may or may not be rewindable (this is done to support
     # streaming HTTP request bodies). If we know a request body is rewindable we can read it
@@ -18,7 +28,62 @@ module Idempo::RequestFingerprint
     Base64.strict_encode64(d.digest)
   end
 
-  def self.read_and_rewind(source_io, to_destination_io)
+  # Extracts a value identifying the user from the request. This value gets
+  # included in the request fingerprint hash. Without user identity in the
+  # fingerprint, two different users sending the same idempotency key to the
+  # same endpoint would receive each other's cached responses — leaking
+  # sensitive data across user boundaries (similar to the Railway CDN caching
+  # incident of March 2026, where responses keyed only on method+URL were
+  # served to the wrong users).
+  #
+  # The default implementation tries two strategies, in order:
+  #
+  # 1. If an Authorization header is present (Bearer token, Basic auth, etc.),
+  #    its full value is used. This is the common case for API applications.
+  #    Different tokens produce different fingerprints, so requests from
+  #    different users are naturally separated.
+  #
+  # 2. If no Authorization header is present, we look for a Rails-style session
+  #    cookie (matching the pattern `_<appname>_session`). This covers the
+  #    common case of Rails applications using cookie-based authentication,
+  #    where the Authorization header is typically empty for all users. The
+  #    encrypted session cookie value differs per user session, so it serves
+  #    as a user identity signal. The cookie value is stable from the client's
+  #    perspective across retries (the client resends the same cookie string
+  #    until it receives a Set-Cookie with a new value), which is what matters
+  #    for idempotency — the retry sends the same fingerprint as the original.
+  #
+  # If neither signal is available (no Authorization header and no Rails
+  # session cookie), the fingerprint will only contain the idempotency key,
+  # URL, method, and body. This is acceptable for unauthenticated endpoints
+  # but DANGEROUS for authenticated endpoints using other identity mechanisms
+  # (custom headers like X-API-Key, non-Rails session cookies, etc.).
+  #
+  # To handle those cases, subclass and override this method:
+  #
+  #   class MyFingerprint < Idempo::RequestFingerprint
+  #     private
+  #     def extract_user_identity(rack_request)
+  #       rack_request.get_header("HTTP_X_API_KEY")
+  #     end
+  #   end
+  #
+  #   use Idempo, compute_fingerprint_via: MyFingerprint.new
+  #
+  def extract_user_identity(rack_request)
+    auth = rack_request.get_header("HTTP_AUTHORIZATION").to_s
+    return auth unless auth.empty?
+    extract_rails_session_cookie(rack_request)
+  end
+
+  def extract_rails_session_cookie(rack_request)
+    rack_request.cookies.each do |name, value|
+      return value if name.match?(RAILS_SESSION_COOKIE_PATTERN)
+    end
+    nil
+  end
+
+  def read_and_rewind(source_io, to_destination_io)
     while (chunk = source_io.read(1024 * 65))
       to_destination_io << chunk
     end

--- a/spec/idempo/request_fingerprint_spec.rb
+++ b/spec/idempo/request_fingerprint_spec.rb
@@ -64,4 +64,140 @@ RSpec.describe Idempo::RequestFingerprint do
 
     expect(fingerprints.uniq.length).to eq(fingerprints.length)
   end
+
+  it "uses the Authorization header when present, ignoring session cookies" do
+    base_env = {
+      "rack.input" => StringIO.new("body"),
+      "SCRIPT_NAME" => "",
+      "PATH_INFO" => "/hello",
+      "REQUEST_METHOD" => "POST",
+      "HTTP_AUTHORIZATION" => "Bearer same-token"
+    }
+
+    request_a = Rack::Request.new(base_env.merge("HTTP_COOKIE" => "_myapp_session=session1"))
+    request_b = Rack::Request.new(base_env.merge("HTTP_COOKIE" => "_myapp_session=session2"))
+
+    fingerprint_a = described_class.call("key1", request_a)
+    fingerprint_b = described_class.call("key1", request_b)
+
+    expect(fingerprint_a).to eq(fingerprint_b)
+  end
+
+  it "falls back to the Rails session cookie when no Authorization header is present" do
+    base_env = {
+      "rack.input" => StringIO.new("body"),
+      "SCRIPT_NAME" => "",
+      "PATH_INFO" => "/hello",
+      "REQUEST_METHOD" => "POST"
+    }
+
+    request_a = Rack::Request.new(base_env.merge("HTTP_COOKIE" => "_myapp_session=abc123"))
+    request_b = Rack::Request.new(base_env.merge("HTTP_COOKIE" => "_myapp_session=xyz789"))
+
+    fingerprint_a = described_class.call("key1", request_a)
+    fingerprint_b = described_class.call("key1", request_b)
+
+    expect(fingerprint_a).not_to eq(fingerprint_b)
+  end
+
+  it "does not match non-Rails cookies as session cookies" do
+    base_env = {
+      "rack.input" => StringIO.new("body"),
+      "SCRIPT_NAME" => "",
+      "PATH_INFO" => "/hello",
+      "REQUEST_METHOD" => "POST"
+    }
+
+    request_a = Rack::Request.new(base_env.merge("HTTP_COOKIE" => "tracking=abc123"))
+    request_b = Rack::Request.new(base_env.merge("HTTP_COOKIE" => "tracking=xyz789"))
+
+    fingerprint_a = described_class.call("key1", request_a)
+    fingerprint_b = described_class.call("key1", request_b)
+
+    expect(fingerprint_a).to eq(fingerprint_b)
+  end
+
+  context "with a subclass overriding extract_user_identity" do
+    let(:custom_fingerprinter_class) do
+      Class.new(described_class) do
+        private
+
+        def extract_user_identity(rack_request)
+          rack_request.get_header("HTTP_X_USER_ID")
+        end
+      end
+    end
+
+    it "uses the overridden method for user identity" do
+      fingerprinter = custom_fingerprinter_class.new
+      base_env = {
+        "rack.input" => StringIO.new("body"),
+        "SCRIPT_NAME" => "",
+        "PATH_INFO" => "/hello",
+        "REQUEST_METHOD" => "POST"
+      }
+
+      request_a = Rack::Request.new(base_env.merge("HTTP_X_USER_ID" => "user-1"))
+      request_b = Rack::Request.new(base_env.merge("HTTP_X_USER_ID" => "user-2"))
+
+      fingerprint_a = fingerprinter.call("key1", request_a)
+      fingerprint_b = fingerprinter.call("key1", request_b)
+
+      expect(fingerprint_a).not_to eq(fingerprint_b)
+    end
+
+    it "no longer uses the authorization header" do
+      fingerprinter = custom_fingerprinter_class.new
+      base_env = {
+        "rack.input" => StringIO.new("body"),
+        "SCRIPT_NAME" => "",
+        "PATH_INFO" => "/hello",
+        "REQUEST_METHOD" => "POST",
+        "HTTP_X_USER_ID" => "user-1"
+      }
+
+      request_a = Rack::Request.new(base_env.merge("HTTP_AUTHORIZATION" => "Bearer aaa"))
+      request_b = Rack::Request.new(base_env.merge("HTTP_AUTHORIZATION" => "Bearer bbb"))
+
+      fingerprint_a = fingerprinter.call("key1", request_a)
+      fingerprint_b = fingerprinter.call("key1", request_b)
+
+      expect(fingerprint_a).to eq(fingerprint_b)
+    end
+  end
+
+  context "when used as an instance passed to compute_fingerprint_via:" do
+    it "produces the same fingerprint as the class-level call" do
+      fingerprinter = described_class.new
+      rack_env = {
+        "rack.input" => StringIO.new("body"),
+        "SCRIPT_NAME" => "",
+        "PATH_INFO" => "/hello",
+        "REQUEST_METHOD" => "GET",
+        "HTTP_AUTHORIZATION" => "Bearer abcdef"
+      }
+      request = Rack::Request.new(rack_env)
+
+      class_fingerprint = described_class.call("key1", request)
+      rack_env["rack.input"].rewind
+      instance_fingerprint = fingerprinter.call("key1", request)
+
+      expect(instance_fingerprint).to eq(class_fingerprint)
+    end
+  end
+
+  it "calls extract_user_identity during fingerprint computation so that subclass overrides take effect" do
+    fingerprinter = described_class.new
+    rack_env = {
+      "rack.input" => StringIO.new("body"),
+      "SCRIPT_NAME" => "",
+      "PATH_INFO" => "/hello",
+      "REQUEST_METHOD" => "POST",
+      "HTTP_AUTHORIZATION" => "Bearer token"
+    }
+    request = Rack::Request.new(rack_env)
+
+    expect(fingerprinter).to receive(:extract_user_identity).with(request).and_call_original
+    fingerprinter.call("key1", request)
+  end
 end


### PR DESCRIPTION
The request identification is - surprisingly - the trickiest bit in Idempo, and it was up for some reworking.

## Summary

- Converts `RequestFingerprint` from a module to a class with an overridable `extract_user_identity` method
- Default implementation checks the `Authorization` header first; if empty, falls back to the Rails session cookie (`_<appname>_session`)
- Prevents cross-user response leakage for cookie-based auth Rails apps where the Authorization header is empty for all users
- Fully backward compatible: `self.call` delegates to `new.call`, so `RequestFingerprint` still works as the default `compute_fingerprint_via:` value
- Updates the JWT issuer example to use the subclass pattern instead of a standalone module

## Context

Inspired by the [Railway CDN caching incident (March 2026)](https://joshuabellew.com/posts/railway-cdn-caching-incident-march-2026/), where responses keyed only on method+URL were served to wrong users. A similar class of vulnerability existed in Idempo for cookie-auth apps, since the fingerprint only included the Authorization header — which is empty for all users in a typical Rails cookie-session setup. Note that the previous implementation was NOT susceptible to cross-account leakage as long as a real Authorization header was being used; this change adds protection for the cookie-auth case.